### PR TITLE
fix rotation of incorrect image

### DIFF
--- a/src/DataContainer/Files.php
+++ b/src/DataContainer/Files.php
@@ -53,7 +53,7 @@ class Files extends Backend
                 $isGdImage = true;
                 $request = $this->requestStack->getCurrentRequest();
 
-                if ('rotate_image' === $request->query->get('key')) {
+                if ('rotate_image' === $request->query->get('key') && $strDecoded === $request->query->get('id')) {
                     $this->rotateImage->rotateImage($objFile);
                 }
             }


### PR DESCRIPTION
No matter which image you try to rotate, always the first image in the file list is rotated because the id is never compared.

See also: https://community.contao.org/de/showthread.php?85657-markocupic-rotate_image-nur-erstes-Bild-wird-gedreht